### PR TITLE
Implemented Multiple Devices and Hot Plugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,26 @@ This is a drop in DLL replacement for *xinput1_3.dll* that provides DirectInput 
 
 Drop all included files into *installdirectory\StreetFighterV\Binaries\Win64\* and launch the game. To uninstall, just remove the dll files from this folder.
 
-## Features (as of alpha release)
+## Features
 
-1. A single DirectInput controller will work, alongside XInput controllers.
-2. By holding the Home Button and left or right on the DPad, you can switch between being player 1 or player 2 on the DirectInput controller.
+1. Supports DirectInput as well as XInput devices
+2. By holding the Home Button and left or right on the DPad, you can switch between being player 1 or player 2 on any controller (on XInput controller Start+Back can be used if it's not working).
+3. You can plug or unplug your devices while the game is running
+4. Devices are automatically assigned (first plugged, first player assigned, places are kept).
 
 ## Known Bugs
 
-1. This currently only supports a single DirectInput controller
-2. The DirectInput controller cannot be unplugged and replugged without restarting the game
-3. Doesn't work with controllers that use the Analog Joystick, only controllers that use the DPad/Hatswitch
-4. Controllers that aren't PS3/PS4 controllers don't have a way to get proper mapping :(
+1. Doesn't work with controllers that use the Analog Joystick, only controllers that use the DPad/Hatswitch
+2. Controllers that aren't PS3/PS4 controllers don't have a way to get proper mapping :(
 
 ## Tested with....
 
 1. Hori FC4
 2. Sony DualShock 4
 3. Hori PS4 VLX
+4. PS360+ in any mode
 
 ## Credits
 
 * @dantarion
+* @WydD

--- a/xinput1_3/xinput1_3.cpp
+++ b/xinput1_3/xinput1_3.cpp
@@ -526,11 +526,11 @@ DWORD WINAPI hooked_XInputGetState(DWORD dwUserIndex, XINPUT_STATE *pState)
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_LEFT_SHOULDER;
 	if (js->rgbButtons[6])
 		pState->Gamepad.bLeftTrigger = 255;
-	if (js->rgbButtons[7])
-		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_START;
 	if (js->rgbButtons[8])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_BACK;
 	if (js->rgbButtons[9])
+		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_START;
+	if (js->rgbButtons[10])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_LEFT_THUMB;
 	if (js->rgbButtons[11])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_RIGHT_THUMB;

--- a/xinput1_3/xinput1_3.cpp
+++ b/xinput1_3/xinput1_3.cpp
@@ -527,9 +527,9 @@ DWORD WINAPI hooked_XInputGetState(DWORD dwUserIndex, XINPUT_STATE *pState)
 	if (js->rgbButtons[6])
 		pState->Gamepad.bLeftTrigger = 255;
 	if (js->rgbButtons[7])
-		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_BACK;
-	if (js->rgbButtons[8])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_START;
+	if (js->rgbButtons[8])
+		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_BACK;
 	if (js->rgbButtons[9])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_LEFT_THUMB;
 	if (js->rgbButtons[11])

--- a/xinput1_3/xinput1_3.cpp
+++ b/xinput1_3/xinput1_3.cpp
@@ -9,15 +9,56 @@
 #pragma comment(lib, "dinput8.lib")
 #pragma comment(lib, "dxguid.lib")
 #include <cstdio>
+#include <unordered_map>
+#include <fstream>
+
+typedef struct
+{
+	WORD wButtons;
+	BYTE bLeftTrigger;
+	BYTE bRightTrigger;
+	SHORT sThumbLX;
+	SHORT sThumbLY;
+	SHORT sThumbRX;
+	SHORT sThumbRY;
+	DWORD dwPaddingReserved; // Adding padding to avoid crashes when using the ExportByOrdinal100
+} XINPUT_GAMEPAD_EX;
+
+typedef struct
+{
+	DWORD dwPacketNumber;
+	XINPUT_GAMEPAD_EX Gamepad;
+} XINPUT_STATE_EX;
+
+namespace std
+{
+	template<> struct hash<GUID> : public std::_Bitwise_hash<GUID>{};
+}
+
 LPDIRECTINPUT8 di;
-HRESULT hr;
+BOOL diAvailable = true;
+std::unordered_map<GUID, LPDIRECTINPUTDEVICE8> joysticks;
+std::unordered_map<GUID, BOOL> isXInput;
+std::unordered_map<GUID, DIJOYSTATE2> joystick_state;
+
+struct VirtualControllerMapping
+{
+	bool free = true;
+	// if xinput < 0, then guid is used
+	short xinput = -1;
+	GUID guid;
+};
+XINPUT_STATE_EX xinputStates[4];
+bool xinputReady[4];
+VirtualControllerMapping virtualControllers[2];
+int timer = 0;
+
 
 
 /* Wrapper DLL stuff...not important */
 #pragma region Wrapper DLL Stuff
 HINSTANCE mHinst = 0, mHinstDLL = 0;
 extern "C" UINT_PTR mProcs[12] = {0};
-int setupDInput();
 LPCSTR mImportNames[] = {"DllMain", "XInputEnable", "XInputGetBatteryInformation", "XInputGetCapabilities", "XInputGetDSoundAudioDeviceGuids", "XInputGetKeystroke", "XInputGetState", "XInputSetState", (LPCSTR)100, (LPCSTR)101, (LPCSTR)102, (LPCSTR)103};
 BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved ) {
 	mHinst = hinstDLL;
@@ -28,6 +69,17 @@ BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved ) {
 		for ( int i = 0; i < 12; i++ )
 			mProcs[ i ] = (UINT_PTR)GetProcAddress( mHinstDLL, mImportNames[ i ] );
 	} else if ( fdwReason == DLL_PROCESS_DETACH ) {
+		// Releasing resources
+		for (auto it : joysticks) {
+			if (it.second) {
+				it.second->Unacquire();
+				it.second->Release();
+			}
+		}
+		joysticks.clear();
+		if (di) {
+			di->Release();
+		}
 		FreeLibrary( mHinstDLL );
 	}
 	return ( TRUE );
@@ -40,7 +92,7 @@ extern "C" void XInputGetDSoundAudioDeviceGuids_wrapper();
 extern "C" void XInputGetKeystroke_wrapper();
 extern "C" void XInputGetState_wrapper();
 extern "C" void XInputSetState_wrapper();
-extern "C" void ExportByOrdinal100();
+extern "C" DWORD ExportByOrdinal100(_In_  DWORD dwUserIndex, _Out_ XINPUT_STATE_EX *pState);
 extern "C" void ExportByOrdinal101();
 extern "C" void ExportByOrdinal102();
 extern "C" void ExportByOrdinal103();
@@ -59,7 +111,7 @@ The following code checks if a device is an XInput device. We don't need to let 
 // "IG_" (ex. "VID_045E&PID_028E&IG_00").  If it does, then it's an XInput device
 // Unfortunately this information can not be found by just using DirectInput 
 //-----------------------------------------------------------------------------
-BOOL IsXInputDevice(const GUID* pGuidProductFromDirectInput)
+BOOL isXInputDevice(const GUID* pGuidProductFromDirectInput)
 {
 	IWbemLocator*           pIWbemLocator = NULL;
 	IEnumWbemClassObject*   pEnumDevices = NULL;
@@ -165,91 +217,42 @@ LCleanup:
 
 	return bIsXinputDevice;
 }
-//TODO change these to arrays to support more than one DirectInput controller
-LPDIRECTINPUTDEVICE8 joystick;
-DIJOYSTATE2 js;
 
 BOOL CALLBACK enumCallback(const DIDEVICEINSTANCE* instance, VOID* context)
 {
 	HRESULT hr;
-	if (IsXInputDevice(&instance->guidProduct))//Don't mess with XInput devices
+	BOOL xinput = false;
+
+	// First check if the device is known
+	auto it = isXInput.find(instance->guidInstance);
+	if (it == isXInput.end()) {
+		// Not found yet, so check if it is an XInputDevice
+		xinput = isXInputDevice(&instance->guidProduct);
+		isXInput[instance->guidInstance] = xinput;
+	} else {
+		xinput = it->second;
+	}
+
+	if (xinput) {
+		// If it is an xinput, we can safely ignore
 		return DIENUM_CONTINUE;
+	}
+
+	// Check if we have a live DI instance of this joystick
+	if (joysticks.find(instance->guidInstance) != joysticks.end()) {
+		return DIENUM_CONTINUE;
+	}
+
+	// If not we must build it...
+
+	LPDIRECTINPUTDEVICE8 joystick;
 	// Obtain an interface to the enumerated joystick.
 	hr = di->CreateDevice(instance->guidInstance, &joystick, NULL);
-
 	// If it failed, then we can't use this joystick. (Maybe the user unplugged
 	// it while we were in the middle of enumerating it.)
 	if (FAILED(hr)) {
 		return DIENUM_CONTINUE;
 	}
-
-	// Stop enumeration. Note: we're just taking the first joystick we get. You
-	// could store all the enumerated joysticks and let the user pick.
-	//TODO multiple joystick support..i.e. enumerate through all
-	return DIENUM_STOP;
-}
-
-HRESULT
-poll(DIJOYSTATE2 *js)
-{
-	HRESULT     hr;
-
-	if (joystick == NULL) {
-		return S_OK;
-	}
-
-
-	// Poll the device to read the current state
-	hr = joystick->Poll();
-	if (FAILED(hr)) {
-		// DInput is telling us that the input stream has been
-		// interrupted. We aren't tracking any state between polls, so
-		// we don't have any special reset that needs to be done. We
-		// just re-acquire and try again.
-		hr = joystick->Acquire();
-		while (hr == DIERR_INPUTLOST) {
-			hr = joystick->Acquire();
-		}
-
-		// If we encounter a fatal error, return failure.
-		if ((hr == DIERR_INVALIDPARAM) || (hr == DIERR_NOTINITIALIZED)) {
-			return E_FAIL;
-		}
-
-		// If another application has control of this device, return successfully.
-		// We'll just have to wait our turn to use the joystick.
-		if (hr == DIERR_OTHERAPPHASPRIO) {
-			return S_OK;
-		}
-	}
-
-	// Get the input's device state
-	if (FAILED(hr = joystick->GetDeviceState(sizeof(DIJOYSTATE2), js))) {
-		return hr; // The device should have been acquired during the Poll()
-	}
-
-	return S_OK;
-}
-int setupDInput()
-{
-	// Create a DirectInput device
-	if(hr == NULL)
-		if (FAILED(hr = DirectInput8Create(GetModuleHandle(NULL), DIRECTINPUT_VERSION,
-			IID_IDirectInput8, (VOID**)&di, NULL))) {
-			return (FALSE);
-		}
-	// Look for the first simple joystick we can find.
-	if (FAILED(hr = di->EnumDevices(DI8DEVCLASS_GAMECTRL, enumCallback,
-		NULL, DIEDFL_ATTACHEDONLY))) {
-		printf("Joystick not found.\n");
-	}
-
-	// Make sure we got a joystick
-	if (joystick == NULL) {
-		printf("Joystick not found.\n");
-		return FALSE;
-	}
-	DIDEVCAPS capabilities;
 
 	// Set the data format to "simple joystick" - a predefined data format 
 	//
@@ -257,75 +260,277 @@ int setupDInput()
 	// and how they should be reported. This tells DInput that we will be
 	// passing a DIJOYSTATE2 structure to IDirectInputDevice::GetDeviceState().
 	if (FAILED(hr = joystick->SetDataFormat(&c_dfDIJoystick2))) {
-		printf("Format is fucked.\n");
-		return hr;
+		printf("SetDataFormat is fucked %x\n", hr);
+		joystick->Release();
+		return DIENUM_CONTINUE;
 	}
+
+	// Acquire the device
+	if (FAILED(hr = joystick->Acquire())) {
+		printf("Acquire is fucked %x\n", hr);
+		joystick->Release();
+		return DIENUM_CONTINUE;
+	}
+
+	// Store the joystick instance accessible via guid
+	joysticks[instance->guidInstance] = joystick;
+	joystick_state[instance->guidInstance];
 
 	// Set the cooperative level to let DInput know how this device should
 	// interact with the system and with other DInput applications.
-	if (FAILED(hr = joystick->SetCooperativeLevel(NULL, DISCL_EXCLUSIVE |
-		DISCL_FOREGROUND))) {
-		printf("Coop is fucked\n");
-		return hr;
+	if (FAILED(hr = joystick->SetCooperativeLevel(NULL, DISCL_NONEXCLUSIVE | DISCL_FOREGROUND))) {
+		printf("Coop is fucked %x\n", hr);
+		// Not that important actually
 	}
 
-	// Determine how many axis the joystick has (so we don't error out setting
-	// properties for unavailable axis)
-	capabilities.dwSize = sizeof(DIDEVCAPS);
-	if (FAILED(hr = joystick->GetCapabilities(&capabilities))) {
-		printf("Cap is fucked\n");
-		return hr;
-	}
+	// Get other devices
+	return DIENUM_CONTINUE;
 }
-XINPUT_STATE STATES[2];
-int binding = 0;
+HRESULT
+poll(LPDIRECTINPUTDEVICE8 joystick, LPDIJOYSTATE2 js)
+{
+	// Device polling (as seen on x360ce)
+	HRESULT hr = E_FAIL;
+
+	if (!joystick) return E_FAIL;
+
+	joystick->Poll();
+	hr = joystick->GetDeviceState(sizeof(DIJOYSTATE2), js);
+
+	if (FAILED(hr)) {
+		// Reacquire the device (only once)
+		hr = joystick->Acquire();
+	}
+
+	return hr;
+}
+
+int setupDInput()
+{
+	if (!diAvailable) {
+		return FALSE;
+	}
+	// Create a DirectInput8 instance
+	if (di == NULL) {
+		if (FAILED(DirectInput8Create(GetModuleHandle(NULL), DIRECTINPUT_VERSION,
+			IID_IDirectInput8, (VOID**)&di, NULL))) {
+			// If it is not available for any reason, avoid getting back in setupDInput
+			diAvailable = false;
+			return (FALSE);
+		}
+	}
+
+	// Poll all devices
+	if (FAILED(di->EnumDevices(DI8DEVCLASS_GAMECTRL, enumCallback,
+		NULL, DIEDFL_ATTACHEDONLY))) {
+		return FALSE;
+	}
+	return TRUE;
+}
+
+// From a DI state, check if we want a controller change
+// Returns -1 if nothing must change, or the id of the controller
+int readDirectInputControllerChange(DIJOYSTATE2* input) {
+	//If DirectInput HOME + LPAD RIGHT
+	if ((input->rgdwPOV[0] == 5 * 4500 || input->rgdwPOV[0] == 6 * 4500 || input->rgdwPOV[0] == 7 * 4500) && input->rgbButtons[12])
+		return 0;
+	//If DirectInput HOME + DPAD RIGHT
+	if ((input->rgdwPOV[0] == 1 * 4500 || input->rgdwPOV[0] == 2 * 4500 || input->rgdwPOV[0] == 3 * 4500) && input->rgbButtons[12])
+		return 1;
+	return -1;
+}
+
+// From an XINPUT state, check if we want a controller change
+// Returns -1 if nothing must change, or the id of the controller
+int readXInputControllerChange(XINPUT_STATE_EX* input) {
+	// Select guide (or SELECT + START)
+	BOOL guideSelected = (input->Gamepad.wButtons & 0x400) || ((input->Gamepad.wButtons & XINPUT_GAMEPAD_START) && (input->Gamepad.wButtons & XINPUT_GAMEPAD_BACK));
+	// ... and direction...
+	if (guideSelected && (input->Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_LEFT)) {
+		return 0;
+	}
+	if (guideSelected && (input->Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_LEFT)) {
+		return 1;
+	}
+	return -1;
+}
+
+// Returns true iff the virtual controller contains the given argument
+BOOL mappingContains(VirtualControllerMapping* mapping, const GUID* dinputGUID, short xinputIndex) {
+	if (mapping->free) {
+		return false;
+	}
+	if (xinputIndex < 0) {
+		return memcmp(dinputGUID, &mapping->guid, sizeof(GUID)) == 0;
+	}
+	return mapping->xinput == xinputIndex;
+}
+
+
+void selectController(int desired, const GUID* dinputGUID, short xinputIndex) {
+	if (desired < 0) {
+		// Nothing is desired BUT if a place is free then...
+		if (virtualControllers[0].free && !mappingContains(&virtualControllers[1], dinputGUID, xinputIndex)) {
+			selectController(0, dinputGUID, xinputIndex);
+		} else if (virtualControllers[1].free && !mappingContains(&virtualControllers[0], dinputGUID, xinputIndex)) {
+			selectController(1, dinputGUID, xinputIndex);
+		}
+		return;
+	}
+
+	VirtualControllerMapping* targetMapping = &virtualControllers[desired];
+	if (mappingContains(targetMapping, dinputGUID, xinputIndex)) {
+		// We already have the right one on the desired index
+		return;
+	}
+	
+	// Selecting the controller now...
+	VirtualControllerMapping* otherMapping = &virtualControllers[1-desired];
+	if (!targetMapping->free) {
+		// If we require a controller that is already taken, swap the two
+		*otherMapping = *targetMapping;
+	} else {
+		// If we switch to a free space
+		if (mappingContains(otherMapping, dinputGUID, xinputIndex)) {
+			// Release the one if we had before
+			otherMapping->free = true;
+		}
+	}
+
+	// Set the actual mapping
+	if (dinputGUID != NULL) {
+		targetMapping->guid = *dinputGUID;
+	}
+	targetMapping->xinput = xinputIndex;
+	targetMapping->free = false;
+}
+// Returns an empty device instead of ERROR_DEVICE_NOT_CONNECTED
+// This asks SFV to always poll device 0 and 1
+DWORD emptyDevice(XINPUT_STATE* pState) {
+	ZeroMemory(pState, sizeof(XINPUT_STATE));
+	return ERROR_SUCCESS;
+}
+
+// XInputGetState implementation
 DWORD WINAPI hooked_XInputGetState(DWORD dwUserIndex, XINPUT_STATE *pState)
 {
-	if(di == NULL)
-		setupDInput();
-	poll(&js);
+	// We dont support >= 2
+	if (dwUserIndex >= 2) {
+		return ERROR_DEVICE_NOT_CONNECTED;
+	}
 
-	//Check for binding change...
-	//If DirectInput HOME + DPAD LEFT
-	if ((js.rgdwPOV[0] == 5 * 4500 || js.rgdwPOV[0] == 6 * 4500 || js.rgdwPOV[0] == 7 * 4500) && js.rgbButtons[12])
-		binding = 0;
-	//If DirectInput HOME + DPAD RIGHT
-	if ((js.rgdwPOV[0] == 1 * 4500 || js.rgdwPOV[0] == 2 * 4500 || js.rgdwPOV[0] == 3 * 4500) && js.rgbButtons[12])
-		binding = 1;
+	// Make the reads on 0 then dispatch on the rest
+	if (dwUserIndex == 0) {
+		// Once every second
+		if (timer % 60 == 0) {
+			// Refresh device list
+			setupDInput();
+			timer = 0;
+		}
+		++timer;
 
-	int ret = XInputGetState(dwUserIndex, pState);
-	//If the DirectInput Controller is not bound to this slot...
-	if (binding != dwUserIndex)
-		return ERROR_SUCCESS;//Return normally
+		// Read DI joysticks
+		for (auto it = joysticks.begin(); it != joysticks.end(); ) {
+			LPDIJOYSTATE2 state = &joystick_state[it->first];
+			// Poll the device
+			if (FAILED(poll(it->second, state))) {
+				// We cant poll the device
+				// it must be removed from the list of available joysticks
+				it->second->Unacquire();
+				it->second->Release();
+				joystick_state.erase(it->first);
+				it = joysticks.erase(it);
+				continue;
+			}
+
+			// Check if the device wants to be changed
+			int desired = readDirectInputControllerChange(state);
+			// Set the virtual controller if necessary
+			selectController(desired, &it->first, -1);
+			++it;
+		}
+
+		// Read XInput
+		for (int i = 0; i < 4; i++) {
+			// Read XInputGetStateEx to get the GUIDE button (though it seems to be broken on win10 now)
+			if (ExportByOrdinal100(i, &xinputStates[i]) != ERROR_SUCCESS) {
+				xinputReady[i] = false;
+				continue;
+			}
+			xinputReady[i] = true;
+			// Check if the device wants to be changed
+			int desired = readXInputControllerChange(&xinputStates[i]);
+			// Set the virtual controller if necessary
+			selectController(desired, NULL, i);
+		}
+	}
+
+	// Get the mapping
+	VirtualControllerMapping* mapping = &virtualControllers[dwUserIndex];
+	
+	if (mapping->free) {
+		// No device for this one, give the empty device
+		return emptyDevice(pState);
+	}
+
+	// We have something
+
+	if (mapping->xinput >= 0) {
+		// XInput!
+		if (!xinputReady[mapping->xinput]) {
+			// But it was disconnected...
+			mapping->free = true;
+			return emptyDevice(pState);
+		}
+		// Else, just copy the input to the pState
+		memcpy(pState, &xinputStates[mapping->xinput], sizeof(XINPUT_STATE));
+		return ERROR_SUCCESS;
+	}
+
+	// This is a DirectInput device
+
+	if (joysticks.find(mapping->guid) == joysticks.end()) {
+		// But it has been destroy
+		mapping->free = true;
+		return emptyDevice(pState);
+	}
+
+	// Do the actual mapping now
+	LPDIJOYSTATE2 js = &joystick_state[mapping->guid];
+	pState->dwPacketNumber = GetTickCount();
 
 	//If the DirectInput Controller is bound to this slot, inject button inputs
-	if (js.rgbButtons[0])
+	if (js->rgbButtons[0])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_X;
-	if (js.rgbButtons[3])
+	if (js->rgbButtons[3])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_Y;
-	if (js.rgbButtons[1])
+	if (js->rgbButtons[1])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_A;
-	if (js.rgbButtons[2])
+	if (js->rgbButtons[2])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_B;
-	if (js.rgbButtons[5])
+	if (js->rgbButtons[5])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_RIGHT_SHOULDER;
-	if (js.rgbButtons[7])
+	if (js->rgbButtons[7])
 		pState->Gamepad.bRightTrigger = 255;
-	if (js.rgbButtons[4])
+	if (js->rgbButtons[4])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_LEFT_SHOULDER;
-	if (js.rgbButtons[6])
+	if (js->rgbButtons[6])
 		pState->Gamepad.bLeftTrigger = 255;
-	if (js.rgbButtons[9])
+	if (js->rgbButtons[7])
+		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_BACK;
+	if (js->rgbButtons[8])
+		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_START;
+	if (js->rgbButtons[9])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_LEFT_THUMB;
-	if (js.rgbButtons[11])
+	if (js->rgbButtons[11])
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_RIGHT_THUMB;
-	if (js.rgdwPOV[0] == 0 * 4500 || js.rgdwPOV[0] == 1 * 4500 || js.rgdwPOV[0] == 7 * 4500)
+	if (js->rgdwPOV[0] == 0 * 4500 || js->rgdwPOV[0] == 1 * 4500 || js->rgdwPOV[0] == 7 * 4500)
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP;
-	if (js.rgdwPOV[0] == 1 * 4500 || js.rgdwPOV[0] == 2 * 4500 || js.rgdwPOV[0] == 3 * 4500)
+	if (js->rgdwPOV[0] == 1 * 4500 || js->rgdwPOV[0] == 2 * 4500 || js->rgdwPOV[0] == 3 * 4500)
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_RIGHT;
-	if (js.rgdwPOV[0] == 3 * 4500 || js.rgdwPOV[0] == 4 * 4500 || js.rgdwPOV[0] == 5 * 4500)
+	if (js->rgdwPOV[0] == 3 * 4500 || js->rgdwPOV[0] == 4 * 4500 || js->rgdwPOV[0] == 5 * 4500)
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN;
-	if (js.rgdwPOV[0] == 5 * 4500 || js.rgdwPOV[0] == 6 * 4500 || js.rgdwPOV[0] == 7 * 4500)
+	if (js->rgdwPOV[0] == 5 * 4500 || js->rgdwPOV[0] == 6 * 4500 || js->rgdwPOV[0] == 7 * 4500)
 		pState->Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_LEFT;
 	//TODO ANALOG JOYSTICK
 


### PR DESCRIPTION
So I tried to do this because I think it can be of critical use (especially for local tournaments).
I rewrote most of the code but I wanted to start from your template because it had the injection part running.

Basically, the idea is to read all device data once every frame (when sfv check for XInputGetState(0,...)) and then manage virtualControllers[2] with the right mappings.
Device check is operated once every second, or 60 calls of XInputGetState to avoid spaming EnumDevices.

After that, it's a matter of managing the structures and calling the right things.

I tried to bind the GUIDE button on XInput but unfortunately even the XInputGetStateEx does not seem to give me 0x400 on my computer. It worked a few month ago though. I added a binding of Start+Back = Home for xinput devices to select which player you want.

See ya
