### PR TITLE
Adding _Bitwise_hash definition 

### DIFF
--- a/xinput1_3/fnv1a.hpp
+++ b/xinput1_3/fnv1a.hpp
@@ -1,0 +1,44 @@
+#pragma once
+/*
+VCSamples
+Copyright (c) Microsoft Corporation
+All rights reserved.
+MIT License
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include <stddef.h>
+
+inline size_t fnv1a_hash_bytes(const unsigned char* first, size_t count) {
+#if defined(_WIN64)
+	static_assert(sizeof(size_t) == 8, "This code is for 64-bit size_t.");
+	const size_t fnv_offset_basis = 14695981039346656037ULL;
+	const size_t fnv_prime = 1099511628211ULL;
+
+#else /* defined(_WIN64) */
+	static_assert(sizeof(size_t) == 4, "This code is for 32-bit size_t.");
+	const size_t fnv_offset_basis = 2166136261U;
+	const size_t fnv_prime = 16777619U;
+#endif /* defined(_WIN64) */
+
+	size_t result = fnv_offset_basis;
+	for (size_t next = 0; next < count; ++next)
+	{	// fold in another byte
+		result ^= (size_t)first[next];
+		result *= fnv_prime;
+	}
+	return (result);
+}

--- a/xinput1_3/xinput1_3.cpp
+++ b/xinput1_3/xinput1_3.cpp
@@ -1,9 +1,21 @@
 #include "stdafx.h"
 #include "wrapped.h"
+#include "fnv1a.hpp"
 
 // Hashing structure for GUID
 namespace std
 {
+	template<class _Kty>
+	struct _Bitwise_hash
+	{	// hash functor for plain old data
+		typedef _Kty argument_type;
+		typedef size_t result_type;
+
+		size_t operator()(const _Kty& _Keyval) const
+		{	// hash _Keyval to size_t value by pseudorandomizing transform
+			return (fnv1a_hash_bytes((const unsigned char*)&_Keyval, sizeof(_Kty)));
+		}
+	};
 	template<> struct hash<GUID> : public std::_Bitwise_hash<GUID>{};
 }
 // DI stuff

--- a/xinput1_3/xinput1_3.vcxproj
+++ b/xinput1_3/xinput1_3.vcxproj
@@ -30,27 +30,27 @@
     <ProjectGuid>{3941E9F8-2E29-4D69-8717-F74562ED5301}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xinput1_3</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>false</CLRSupport>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
@@ -59,7 +59,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>false</CLRSupport>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
@@ -68,7 +68,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>false</CLRSupport>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
@@ -77,7 +77,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>false</CLRSupport>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>

--- a/xinput1_3/xinput1_3.vcxproj
+++ b/xinput1_3/xinput1_3.vcxproj
@@ -271,6 +271,7 @@
     <None Include="xinput1_3.def" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="fnv1a.hpp" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="utils.h" />

--- a/xinput1_3/xinput1_3.vcxproj.filters
+++ b/xinput1_3/xinput1_3.vcxproj.filters
@@ -38,6 +38,9 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="fnv1a.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="xinput1_3.rc">


### PR DESCRIPTION
_Bitwise_hash doesn't exist in newer build systems on Windows. This change redefines it according to the migration recommendations [here](https://learn.microsoft.com/en-us/cpp/porting/fix-your-dependencies-on-library-internals?view=msvc-170). Hopefully this doesn't break the build for old systems. Someone should test the build on a currently functional build system before merging this.